### PR TITLE
Define artifact id in maven config and run maven in batch mode (-B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ package is put there before packaging. The default is `dist/`. The package file 
 
     var config = {
         "groupId"      : "com.example",    // required - the Maven group id.
+        "artifactId"   : "{name}",         // the Maven artifact id.
         "buildDir"     : "dist",           // project build directory.
         "finalName"    : "{name}",         // the final name of the file created when the built project is packaged.
         "type"         : "war",            // type of package. "war" or "jar" supported.

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var config, pkg, validateConfig, validateRepos, validateRepo;
 init();
 validateConfig = defineOpts({
     groupId       : 'string   - the Maven group id.',
+    artifactId    : '?|string - the Maven artifact id. default "' + config.artifactId + '".',
     buildDir      : '?|string - build directory. default "' + config.buildDir + '".',
     finalName     : '?|string - the final name of the file created when the built project is packaged. default "' +
                     config.finalName + '"',
@@ -27,6 +28,7 @@ validateRepo = defineOpts({
 
 function init () {
     config = {
+        artifactId: '{name}',
         buildDir: 'dist',
         finalName: '{name}',
         type: 'war',
@@ -61,7 +63,7 @@ function mvnArgs (repoId, isSnapshot) {
         packaging    : config.type,
         file         : archivePath(),
         groupId      : config.groupId,
-        artifactId   : pkg.name,
+        artifactId   : config.artifactId,
         version      : pkg.version
     };
     if (repoId) {
@@ -103,7 +105,7 @@ function command (cmd, done) {
 }
 
 function mvn (args, repoId, isSnapshot, done) {
-    command('mvn ' + args.concat(mvnArgs(repoId, isSnapshot)).join(' '), done);
+    command('mvn -B ' + args.concat(mvnArgs(repoId, isSnapshot)).join(' '), done);
 }
 
 function exit(){


### PR DESCRIPTION
It should be possible to define maven artifact id in maven configuration. Running maven in node without batch mode sometimes hangs the process. 
