### PR TITLE
Read package.json every time the config is used. Fixes Issue #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simple Node.js module to create a war-/jar-package and install/deploy to a local/remote Maven repository",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/jshint .jshintrc *.js",
+    "test": "mocha && npm run lint",
+    "lint": "./node_modules/.bin/jshint *.js",
     "prepublish": "./node_modules/.bin/jshint .jshintrc *.js"
   },
   "keywords": [
@@ -31,8 +32,12 @@
     "isbinaryfile": "2.x"
   },
   "devDependencies": {
+    "chai": "^1.10.0",
     "jshint": "^2.5.5",
     "mocha": "^1.21.4",
-    "shelljs": "^0.3.0"
+    "mock-fs": "^2.5.0",
+    "mockery": "^1.4.0",
+    "proxyquire": "^1.3.1",
+    "sinon": "^1.12.2"
   }
 }


### PR DESCRIPTION
Changed the tests to use mock-fs (a virtual file system) which should be much more robust than reading private variables from index.js.

Then removed the shared `config` variable and use `getConfig()` instead. It will generate a new config object every time, that reads package.json every time. (Every time is not _that_ often).