### PR TITLE
fix path for windows user, make tests pass on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,9 +58,13 @@ function filterConfig (configTmpl, pkg) {
     return obj;
 }
 
+function convertPathIntoUnixLike (path) {
+    return path.replace(/\\/g, '/');
+}
+
 function archivePath () {
     var conf = getConfig();
-    return path.join(conf.buildDir, conf.finalName + '.' + conf.type).replace(/\\/g, '/');
+    return convertPathIntoUnixLike(path.join(conf.buildDir, conf.finalName + '.' + conf.type));
 }
 
 function mvnArgs (repoId, isSnapshot) {
@@ -150,7 +154,7 @@ var maven = {
                 data = fs.readFileSync(filePath, {'encoding': conf.fileEncoding});
             }
 
-            archive.file(path.relative(conf.buildDir, filePath).replace(/\\/g, '/'), data);
+            archive.file(convertPathIntoUnixLike(path.relative(conf.buildDir, filePath)), data);
         });
 
         var buffer = archive.generate({type:'nodebuffer', compression:'DEFLATE'});

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function filterConfig (configTmpl, pkg) {
 
 function archivePath () {
     var conf = getConfig();
-    return path.join(conf.buildDir, conf.finalName + '.' + conf.type);
+    return path.join(conf.buildDir, conf.finalName + '.' + conf.type).replace(/\\/g, '/');
 }
 
 function mvnArgs (repoId, isSnapshot) {
@@ -150,7 +150,7 @@ var maven = {
                 data = fs.readFileSync(filePath, {'encoding': conf.fileEncoding});
             }
 
-            archive.file(path.relative(conf.buildDir, filePath), data);
+            archive.file(path.relative(conf.buildDir, filePath).replace(/\\/g, '/'), data);
         });
 
         var buffer = archive.generate({type:'nodebuffer', compression:'DEFLATE'});


### PR DESCRIPTION
There was a problem with creating archive on windows: it created files with foldername\filename names instead of creating actual folder which contains thess files. That's caused by node path module. I havn't seen any better solution for cross-platform compatibility than just replace backslashes with slashes.