### PR TITLE
Optional file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Usage: `maven.deploy( repositoryId, [snapshot = false], [callback])`
     maven.config(config);
     maven.deploy('example-internal-release');
 
+### Example: deploy existing archive file
+
+    var maven = require('maven-deploy');
+    maven.config(config);
+    maven.deploy('example-internal-release', 'file.jar');
+
 ## Contributing
 
 We would love your contribution, please consult the [contributing](CONTRIBUTE.md) page for how to make your contributions land into the project as easily as possible.

--- a/index.js
+++ b/index.js
@@ -163,10 +163,9 @@ function package (isSnapshot, done) {
 
 function mvn (args, repoId, isSnapshot, file, done) {
     if (!file) { file = package(isSnapshot); }
-    var stats = fs.statSync(file);
-    if (!stats.isFile()) {
-        throw new Error('File does not exist: ' + file);
-    }
+
+    // check if file exists
+    fs.statSync(file);
 
     command('mvn -B ' + args.concat(mvnArgs(repoId, isSnapshot, file)).join(' '), done);
 }

--- a/test.js
+++ b/test.js
@@ -213,6 +213,30 @@ describe('maven-deploy', function () {
             assertWarFileToEqual(EXPECTED_FILENAME);
         });
 
+        it('should install file from arguments if specified', function () {
+            const CUSTOM_FILE = 'file-from-args.jar';
+            const EXPECTED_ARGS = ['-Dfile='+CUSTOM_FILE];
+
+            var zip = new JSZip();
+            zip.file('test.txt', 'test');
+            fs.writeFileSync(CUSTOM_FILE, zip.generate({type:'nodebuffer', compression:'DEFLATE'}));
+
+            maven.config(TEST_CONFIG);
+            maven.install(CUSTOM_FILE);
+
+            assertArgs(execSpy.args[0][0], EXPECTED_ARGS);
+        });
+
+        it('should throw error if file from arguments does not exist', function () {
+            const CUSTOM_FILE = 'non-existing-file-from-args.jar';
+            const EXPECTED_ARGS = ['-Dfile='+CUSTOM_FILE];
+            maven.config(TEST_CONFIG);
+
+            assert.throws(function () {
+                maven.install(CUSTOM_FILE);
+            });
+        });
+
         it('should call callback function when done successfully', function () {
             var spy = sinon.spy();
             maven.config(TEST_CONFIG);
@@ -270,16 +294,47 @@ describe('maven-deploy', function () {
             assertArgs(execSpy.args[0][0], EXPECTED_ARGS);
         });
 
+        it('should deploy file from arguments if specified', function () {
+            const CUSTOM_FILE = 'file-from-args.jar';
+            const EXPECTED_ARGS = [
+                '-Dfile='+CUSTOM_FILE,
+                '-Dversion='+TEST_PKG_JSON.version
+            ];
+
+            var zip = new JSZip();
+            zip.file('test.txt', 'test');
+            fs.writeFileSync(CUSTOM_FILE, zip.generate({type:'nodebuffer', compression:'DEFLATE'}));
+
+            maven.config(TEST_CONFIG);
+            maven.deploy(DUMMY_REPO_RELEASE, CUSTOM_FILE);
+            maven.deploy(DUMMY_REPO_RELEASE, CUSTOM_FILE, false);
+            maven.deploy(DUMMY_REPO_RELEASE, CUSTOM_FILE, false, sinon.spy());
+            maven.deploy(DUMMY_REPO_RELEASE, CUSTOM_FILE, sinon.spy());
+
+            assert.equal(execSpy.callCount, 4);
+
+            for (var i=0; i<4; i++) {
+                assertArgs(execSpy.args[i][0], EXPECTED_ARGS);
+            }
+        });
+
         it('should call callback function when done successfully', function () {
             var spy = sinon.spy();
+
             maven.config(TEST_CONFIG);
+            maven.deploy(DUMMY_REPO_RELEASE.id, spy);
             maven.deploy(DUMMY_REPO_RELEASE.id, false, spy);
+            maven.deploy(DUMMY_REPO_RELEASE.id, 'package.json', spy);
+            maven.deploy(DUMMY_REPO_RELEASE.id, 'package.json', false, spy);
 
-            // fake successful exec
-            var execCallback = execSpy.args[0][1];
-            execCallback(null, 'stdout', null);
+            assert.equal(execSpy.callCount, 4);
 
-            assert.ok(spy.calledOnce);
+            for (var i=0; i<4; i++) {
+                // fake successful exec
+                execSpy.args[i][1](null, 'stdout', null);
+            }
+
+            assert.equal(spy.callCount, 4);
             assert.equal(spy.args[0][1], 'stdout');
         });
     });

--- a/test.js
+++ b/test.js
@@ -234,7 +234,7 @@ describe('maven-deploy', function () {
 
             assert.throws(function () {
                 maven.install(CUSTOM_FILE);
-            });
+            }, /ENOENT, no such file or directory/);
         });
 
         it('should call callback function when done successfully', function () {


### PR DESCRIPTION
There has been no way to make an archive yourself and pass the file to maven-deploy. This makes it hard to integrate with tools like Gulp where you probably want to make the archive before passing it to maven-deploy.

This is an attempt to solve this by adding a `file` argument to the `install` and `deploy` functions.

Can someone that use Gulp please check that this actually solves the problem? :innocent: 

Should solve #22 
CC @micha149