### PR TITLE
Added "generatePom" parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const DEFAULT_CONFIG = {
     finalName: '{name}',
     type: 'war',
     fileEncoding: 'utf-8',
-    version: '{version}'
+    version: '{version}',
+    generatePom: true
 };
 
 validateConfig = defineOpts({
@@ -27,7 +28,8 @@ validateConfig = defineOpts({
     finalName     : '?|string - the final name of the file created when the built project is packaged. default "' +
                     DEFAULT_CONFIG.finalName + '"',
     type          : '?|string - "jar" or "war". default "' + DEFAULT_CONFIG.type + '".',
-    fileEncoding  : '?|string - valid file encoding. default "' + DEFAULT_CONFIG.fileEncoding + '"'
+    fileEncoding  : '?|string - valid file encoding. default "' + DEFAULT_CONFIG.fileEncoding + '"',
+    generatePom   : '?|boolean - "true" or "false". default "' + DEFAULT_CONFIG.generatePom + '".'
 });
 
 validateRepos = defineOpts({
@@ -78,7 +80,8 @@ function mvnArgs (repoId, isSnapshot) {
         groupId      : conf.groupId,
         artifactId   : conf.artifactId,
         classifier   : conf.classifier,
-        version      : conf.version
+        version      : conf.version,
+        generatePom  : conf.generatePom
     };
 
     if (repoId) {

--- a/test.js
+++ b/test.js
@@ -29,7 +29,8 @@ const GROUP_ID = 'com.dummy',
     TEST_CONFIG = {
         groupId: GROUP_ID,
         repositories: [DUMMY_REPO_SNAPSHOT, DUMMY_REPO_RELEASE],
-        classifier: TEST_CLASSIFIER
+        classifier: TEST_CLASSIFIER,
+        generatePom: false
     },
     TEST_PKG_JSON = {
         name: 'test-pkg',
@@ -281,6 +282,13 @@ describe('maven-deploy', function () {
 
             assert.ok(spy.calledOnce);
             assert.equal(spy.args[0][1], 'stdout');
+        });
+
+        it('should not generate pom', function () {
+            const EXPECTED_ARGS = ['-DgeneratePom=false'];
+            maven.config(TEST_CONFIG);
+            maven.deploy(DUMMY_REPO_RELEASE.id, false);
+            assertArgs(execSpy.args[0][0], EXPECTED_ARGS);
         });
     });
 


### PR DESCRIPTION
Added "generatePom" parameter. Useful when creating an artifact with 2 different classifiers and the same generated pom. You will get a bad request error because it tries to upload the pom twice. With this parameter you can set the generation and uploading of the pom to false.