### PR TITLE
Support the 'pomFile' argument for install:install-file and deploy:deploy-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ package is put there before packaging. The default is `dist/`. The package file 
         "finalName"    : "{name}",         // the final name of the file created when the built project is packaged.
         "type"         : "war",            // type of package. "war" or "jar" supported.
         "fileEncoding" : "utf-8"           // file encoding when traversing the file system, default is UTF-8
+        "generatePom"  : true,             // generate a POM based on the configuration
+        "pomFile"      : "pom.xml",        // use this existing pom.xml instead of generating one (generatePom must be false)
         "repositories" : [                 // array of repositories, each with id and url to a Maven repository.
           {
             "id": "example-internal-snapshot",

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ validateConfig = defineOpts({
                     DEFAULT_CONFIG.finalName + '"',
     type          : '?|string - "jar" or "war". default "' + DEFAULT_CONFIG.type + '".',
     fileEncoding  : '?|string - valid file encoding. default "' + DEFAULT_CONFIG.fileEncoding + '"',
-    generatePom   : '?|boolean - "true" or "false". default "' + DEFAULT_CONFIG.generatePom + '".'
+    generatePom   : '?|boolean - "true" or "false". default "' + DEFAULT_CONFIG.generatePom + '".',
+    pomFile       : '?|string - filename of an existing pom.xml to use, should be used with generatePom set to "false".'
 });
 
 validateRepos = defineOpts({
@@ -81,7 +82,8 @@ function mvnArgs (repoId, isSnapshot, file) {
         artifactId   : conf.artifactId,
         classifier   : conf.classifier,
         version      : conf.version,
-        generatePom  : conf.generatePom
+        generatePom  : conf.generatePom,
+        pomFile      : conf.pomFile
     };
 
     if (repoId) {

--- a/test.js
+++ b/test.js
@@ -35,6 +35,13 @@ const GROUP_ID = 'com.dummy',
     TEST_PKG_JSON = {
         name: 'test-pkg',
         version: '1.0.0'
+    },
+    TEST_CONFIG_WITH_POM = {
+        groupId: GROUP_ID,
+        repositories: [DUMMY_REPO_SNAPSHOT, DUMMY_REPO_RELEASE],
+        classifier: TEST_CLASSIFIER,
+        generatePom: false,
+        pomFile: 'existing-pom.xml'
     };
 
 var childProcessMock;
@@ -174,6 +181,23 @@ describe('maven-deploy', function () {
                 '-Dclassifier=' + TEST_CLASSIFIER
             ];
             maven.config(TEST_CONFIG);
+            maven.install();
+
+            assertArgs(execSpy.args[0][0], EXPECTED_ARGS);
+        });
+
+        it('should pass pomFile to "mvn" when given', function () {
+            const EXPECTED_ARGS = [
+                '-B',
+                'install:install-file',
+                '-Dpackaging=war',
+                '-Dfile=dist' + path.sep + TEST_PKG_JSON.name + '.war',
+                '-DgroupId=' + GROUP_ID,
+                '-DartifactId=' + TEST_PKG_JSON.name,
+                '-Dclassifier=' + TEST_CLASSIFIER,
+                '-DpomFile=' + TEST_CONFIG_WITH_POM.pomFile
+            ];
+            maven.config(TEST_CONFIG_WITH_POM);
             maven.install();
 
             assertArgs(execSpy.args[0][0], EXPECTED_ARGS);


### PR DESCRIPTION
We're using a specific `pom.xml` generated by another process, and need this pom.xml to be deployed.

Items that our pom.xml contains that cannot be auto-generated:
* license information, inception, etc
* repository pointers