### PR TITLE
Adding support for file paths with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function mvnArgs (repoId, isSnapshot, file) {
     return Object.keys(args).filter(function (key) {
         return typeof args[key] !== 'undefined';
     }).reduce(function (arr, key) {
-        return arr.concat('-D' + key + '=' + args[key]);
+        return arr.concat('"-D' + key + '=' + args[key] + '"');
     }, []);
 }
 

--- a/test.js
+++ b/test.js
@@ -305,7 +305,7 @@ describe('maven-deploy', function () {
         });
 
         it('should add file argument', function () {
-            const EXPECTED_ARGS = ['-Dfile=dist/test-pkg.war'];
+            const EXPECTED_ARGS = ['-Dfile=dist' + path.sep + 'test-pkg.war'];
             maven.config(TEST_CONFIG);
             maven.deploy(DUMMY_REPO_RELEASE.id, false);
             assertArgs(execSpy.args[0][0], EXPECTED_ARGS);


### PR DESCRIPTION
I had a problem with jenkins being installed in c:\Program Files\ and thus spaces in the path that would mess up the mvn deploy commands.
This wraps -Dfile=${path}  in quotes  -Dfile="${path}"  if there's spaces in path.