### PR TITLE
Support semver config option to control how versions are bumped

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ package is put there before packaging. The default is `dist/`. The package file 
         "fileEncoding" : "utf-8",          // file encoding when traversing the file system, default is UTF-8
         "generatePom"  : true,             // generate a POM based on the configuration
         "pomFile"      : "pom.xml",        // use this existing pom.xml instead of generating one (generatePom must be false)
+        "version"      : "{version}",      // sets the final version of the release
+        "semver"       : "minor",          // increases package.json's version. Values here can be any semver.inc release
+                                           // type strings, or an array of the release type and prerelease components.
         "repositories" : [                 // array of repositories, each with id and url to a Maven repository.
           {
             "id": "example-internal-snapshot",
@@ -80,6 +83,43 @@ Usage: `maven.deploy( repositoryId, [snapshot = false], [callback])`
     var maven = require('maven-deploy');
     maven.config(config);
     maven.deploy('example-internal-release', 'file.jar');
+
+## Versioning
+By default, an artifact's version is based on the version in package.json (ie. config.version==='{version}'). To control the version in package.json, you can specify the semver release type param and any prerelease params.
+All prerelease components in the resulting version will be turned into maven qualifiers and separated by '-' instead of '.'. For example 1.2.3-alpha.3 will be 1.2.3-alpha-3
+
+Note: semver is not configured by default for release artifacts.
+
+### Snapshots
+
+All snapshot builds will have the '-SNAPSHOT' qualifier appended to them.
+As well, if a version has prerelease components then the last build number will be dropped in place of the SNAPSHOT qualifier.
+
+Note: semver is set to 'patch' by default for snapshot artifacts.
+
+### Example: bumping the patch version
+
+    console.log(packageJson.version); //1.2.3
+    config.semver = 'patch';
+    maven.config(config);
+    maven.deploy('example-internal-release');
+    //artifact version will be 1.2.4
+
+### Example: bumping the release candidate version
+
+    console.log(packageJson.version); //1.2.3-alpha.3
+    config.semver = ['prerelease', 'alpha'];
+    maven.config(config);
+    maven.deploy('example-internal-release');
+    //artifact version will be 1.2.3-alpha-4
+
+### Example: replacing build numbers with SNAPSHOT
+
+    console.log(packageJson.version); //1.2.3-alpha.3
+    config.semver = ['prerelease', 'alpha'];
+    maven.config(config);
+    maven.deploy('example-internal-release', true);
+    //artifact version will be 1.2.3-alpha-SNAPSHOT
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -159,7 +159,13 @@ function getConfig (isSnapshot) {
         }
 
         //replace the '.' between prerelease components with '-' to be proper qualifiers
-        pkg.version = [semver.major(pkg.version), semver.minor(pkg.version), semver.patch(pkg.version)].join('.') + '-' + components.join('-');
+        if (components.length > 0) {
+            pkg.version = [semver.major(pkg.version), semver.minor(pkg.version), semver.patch(pkg.version)].join('.') + '-' + components.join('-');
+        }
+        else {
+            //should only get here if we popped off the last component, so we don't want to put an extra '-'
+            pkg.version = [semver.major(pkg.version), semver.minor(pkg.version), semver.patch(pkg.version)].join('.')
+        }
     }
 
     //pkg version should be modified above but still need to add snapshot when appropriate

--- a/test.js
+++ b/test.js
@@ -142,6 +142,56 @@ describe('maven-deploy', function () {
         });
     });
 
+    describe('versioning', function() {
+        it('semver release type passed in for releases', function () {
+            const EXPECTED_VERSION = '1.0.1';
+
+            maven.config( extend({finalName: '{name}-{version}', semver: 'patch'}, TEST_CONFIG) );
+            maven.package();
+
+            assertWarFileToEqual(TEST_PKG_JSON.name + '-' + EXPECTED_VERSION + '.war');
+        });
+
+        it('semver release type passed in for snapshots', function () {
+            const EXPECTED_VERSION = '1.1.0-SNAPSHOT';
+
+            maven.config( extend({finalName: '{name}-{version}', semver: 'minor'}, TEST_CONFIG) );
+            maven.package(true);
+
+            assertWarFileToEqual(TEST_PKG_JSON.name + '-' + EXPECTED_VERSION + '.war');
+        });
+
+        it('semver prerelease types for releases', function () {
+            const EXPECTED_VERSION = '1.0.1-beta-0';
+
+            maven.config( extend({finalName: '{name}-{version}', semver: ['prerelease', 'beta']}, TEST_CONFIG) );
+            maven.package();
+
+            assertWarFileToEqual(TEST_PKG_JSON.name + '-' + EXPECTED_VERSION + '.war');
+        });
+
+        it('semver prerelease build number qualifiers', function () {
+            const EXPECTED_VERSION = '1.2.3-6';
+
+            npmVersion('1.2.3-5');
+            maven.config( extend({finalName: '{name}-{version}', semver: ['prerelease']}, TEST_CONFIG) );
+            maven.package();
+
+            assertWarFileToEqual(TEST_PKG_JSON.name + '-' + EXPECTED_VERSION + '.war');
+        });
+
+        it('semver replacing prerelease build numbers with snapshots', function () {
+            const EXPECTED_VERSION = '1.2.3-alpha-SNAPSHOT';
+
+            npmVersion('1.2.3-alpha.5');
+            maven.config( extend({finalName: '{name}-{version}', semver: ['prerelease', 'alpha']}, TEST_CONFIG) );
+            maven.package(true);
+
+            assertWarFileToEqual(TEST_PKG_JSON.name + '-' + EXPECTED_VERSION + '.war');
+        });
+
+    });
+
     describe('package', function () {
         it('should create an archive based on defaults', function () {
             maven.config(TEST_CONFIG);


### PR DESCRIPTION
Adding a new 'semver' config option that can take the semver release type to bump the package.json version before being used to create artifacts.

I needed to specify prerelease components for my versions, as well this should fix #38 too.

I set this up to be backwards compatible (ie there's no version changes for releases and a patch bump for snapshots), so it should be completely invisible off the bat. Otherwise it gives you lots of control to change the version number, and tries to be smart by converting any prerelease components over to maven qualifiers.
