### PR TITLE
added eval of ${var} variables in config templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,15 +53,21 @@ function readPackageJSON (encoding) {
 function filterConfig (configTmpl, pkg) {
     // create a config object from the config template
     // replace {key} with the key's value in package.json
+    // replace ${key} with eval(key)
     var obj = extend({}, configTmpl);
     Object.keys(obj).forEach(function (key) {
         var value = obj[key];
         if (typeof value != 'string') { return; }
 
-        obj[key] = value.replace(/{([^}]+)}/g, function (org, key) {
-            if (pkg[key] === undefined) { return org; }
-            return pkg[key];
-        });
+        obj[key] = value
+            .replace(/\${([^}]+)}/g, function(org, key) {
+                if (eval(key) === undefined) { return org; }
+                return eval(key);
+            })
+            .replace(/{([^}]+)}/g, function (org, key) {
+                if (pkg[key] === undefined) { return org; }
+                return pkg[key];
+            });
     });
 
     return obj;


### PR DESCRIPTION
Now you can add ENV variables or another variables to config.
For example, you want to add build number to version.
You set BUILD_NUMBER to ENV variable, and then write into your config ${process.env.BUILD_NUMBER}

Now, version of config 
var config = {
    "groupId"      : "com.example",    // required - the Maven group id.
    "artifactId"   : "{name}",         // the Maven artifact id.
    "buildDir"     : "dist",           // project build directory.
    "finalName"    : "{name}",         // the final name of the file created when the built project is packaged.
    "type"         : "war",            // type of package. "war" or "jar" supported.
    "fileEncoding" : "utf-8",          // file encoding when traversing the file system, default is UTF-8
    "generatePom"  : true,             // generate a POM based on the configuration
    "pomFile"      : "pom.xml",        // use this existing pom.xml instead of generating one (generatePom must be false)
    "version": "{version}.${process.env.BUILD_NUMBER}-${process.env.NODE_ENV}",
    "repositories" : [                 // array of repositories, each with id and url to a Maven repository.
      {
        "id": "example-internal-snapshot",
        "url": "http://mavenproxy.example.com/example-internal-snapshot/"
      },
      {
        "id": "example-internal-release",
        "url": "http://mavenproxy.example.com/example-internal-release/"
      }
    ]
};

will produce version: 1.0.1.234-production 